### PR TITLE
Single threading

### DIFF
--- a/finrl/meta/data_processors/processor_alpaca.py
+++ b/finrl/meta/data_processors/processor_alpaca.py
@@ -71,7 +71,7 @@ class AlpacaProcessor:
 
         return data_df
 
-     @staticmethod
+    @staticmethod
     def clean_individual_ticker(args):
         tic, df, times = args
         tmp_df = pd.DataFrame(index=times)


### PR DESCRIPTION
Removed multi-threading to memory peak usage, which could crash the script. Still left a number of improvements which greatly speed up the operation